### PR TITLE
add named on RegularExpressionService

### DIFF
--- a/src/java/fr/paris/lutece/plugins/regularexpression/service/RegularExpressionService.java
+++ b/src/java/fr/paris/lutece/plugins/regularexpression/service/RegularExpressionService.java
@@ -41,6 +41,7 @@ import fr.paris.lutece.portal.service.plugin.Plugin;
 import fr.paris.lutece.portal.service.plugin.PluginService;
 import fr.paris.lutece.portal.service.regularexpression.IRegularExpressionService;
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Named;
 import fr.paris.lutece.portal.service.util.AppLogService;
 
 import java.util.List;
@@ -54,6 +55,7 @@ import java.util.regex.PatternSyntaxException;
  *
  */
 @ApplicationScoped
+@Named("regularExpressionService")
 public class RegularExpressionService implements IRegularExpressionService
 {
     /**


### PR DESCRIPTION
It is necessary to add a named on the RegularExpressionService class of the RegularExpression plugin so that the RegularExpressionService class of the core can call this service.